### PR TITLE
Prevent a Core Panic with bind DNS

### DIFF
--- a/src/mgos_captive_portal.c
+++ b/src/mgos_captive_portal.c
@@ -340,12 +340,13 @@ bool mgos_captive_portal_start(void){
 
     // Bind DNS for Captive Portal
     struct mg_connection *dns_c = mg_bind(mgos_get_mgr(), s_listening_addr, dns_ev_handler, 0);
-    mg_set_protocol_dns(dns_c);
 
     if (dns_c == NULL){
-        LOG(LL_ERROR, ("Failed to initialize DNS listener"));
+        // wifi.ap.hostname value should be empty
+        LOG(LL_ERROR, ("Failed to initialize DNS listener, The port may already be in use."));
         return false;
     } else {
+        mg_set_protocol_dns(dns_c);
         LOG(LL_DEBUG, ("Captive Portal DNS Listening on %s", s_listening_addr));
     }
 


### PR DESCRIPTION
Prevent a Core Panic if the DNS port is already in use and explain a possible solution if the error occurs.